### PR TITLE
get: return faster if key is not present

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = function (max) {
 
   return {
     get: function (key) {
+      if (!cache.hasOwnProperty(key) && !_cache.hasOwnProperty(key)) return
       var v = cache[key]
       if(v) return v
       if(v = _cache[key]) {


### PR DESCRIPTION
before:

```csv
name, set, get1, update, get2, evict
hashlru, 7692, 9091, 6667, 7143, 4167
lru-cache, 408, 1563, 840, 2326, 420
lru, 2174, 4348, 4000, 4545, 13
```

after

```csv
name, set, get1, update, get2, evict
hashlru, 8333, 10000, 8333, 10000, 6250
lru-cache, 452, 1695, 794, 2128, 382
lru, 1205, 3704, 3846, 4167, 13
```