### PR TITLE
throw on max absence

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 module.exports = function (max) {
+
+  if (!max) throw Error('hashlru must have a max value, of type number, greater than 0')
+
   var size = 0, cache = Object.create(null), _cache = Object.create(null)
 
   function update (key, value) {

--- a/test/test.js
+++ b/test/test.js
@@ -26,5 +26,7 @@ lru.set('test2', 'test2')
 assert.equal(lru.get('test2'), 'test2')
 
 // object purity:
-
 assert.equal(lru.get('constructor'), undefined)
+
+// max validation:
+assert.throws(HLRU)


### PR DESCRIPTION
If human error is made, and `max` is omitted, original object will grow indefinitely (`size >= undefined` will always be `false` - objects never swap). 

