### PR TITLE
return value on set

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = function (max) {
     set: function (key, value) {
       if(cache[key]) cache[key] = value
       else update(key, value)
+      return value
     }
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -30,3 +30,6 @@ assert.equal(lru.get('constructor'), undefined)
 
 // max validation:
 assert.throws(HLRU)
+
+//set returns value
+assert.equal(lru.set('test5', 'test-foo-bar'), 'test-foo-bar')


### PR DESCRIPTION
This is handy because you can avoid an if statement, instead of doing

```javascript
var value = lru.get('foo');
if (!value) {
 value = compute('foo');
 lru.set('foo', value);
}
...
```

You can do:

```javascript
const value = lru.get('foo') || lru.set('foo', compute('foo'));
...
```

Some of the other LRU implementations on npm I have check implement this.