### PR TITLE
to remove, set as undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,9 @@ module.exports = function (max) {
   }
 
   return {
+    has: function (key) {
+      return key in cache || key in _cache
+    },
     get: function (key) {
       var v = cache[key]
       if(v) return v

--- a/index.js
+++ b/index.js
@@ -16,26 +16,32 @@ module.exports = function (max) {
 
   return {
     has: function (key) {
-      return key in cache || key in _cache
+      return cache[key] !== undefined || _cache[key] !== undefined
     },
     remove: function (key) {
-      if(key in cache) {
-        delete cache[key]
-        size --
-      }
-      delete _cache[key]
+      if(cache[key] !== undefined)
+        cache[key] = undefined
+      if(_cache[key] !== undefined)
+        _cache[key] = undefined
     },
     get: function (key) {
       var v = cache[key]
-      if(v) return v
+      if(v !== undefined) return v
       if(v = _cache[key]) {
         update(key, v)
         return v
       }
     },
     set: function (key, value) {
-      if(cache[key]) cache[key] = value
+      if(cache[key] !== undefined) cache[key] = value
       else update(key, value)
     }
   }
 }
+
+
+
+
+
+
+

--- a/index.js
+++ b/index.js
@@ -18,6 +18,13 @@ module.exports = function (max) {
     has: function (key) {
       return key in cache || key in _cache
     },
+    remove: function (key) {
+      if(key in cache) {
+        delete cache[key]
+        size --
+      }
+      delete _cache[key]
+    },
     get: function (key) {
       var v = cache[key]
       if(v) return v

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,10 @@ lru.set('test', 'test')
 
 assert.equal(lru.get('test'), 'test')
 
+// has:
+assert.equal(lru.has('test'), true)
+assert.equal(lru.has('blah'), false)
+
 // update:
 lru.set('test', 'test2')
 

--- a/test/test.js
+++ b/test/test.js
@@ -34,3 +34,8 @@ assert.equal(lru.get('constructor'), undefined)
 
 // max validation:
 assert.throws(HLRU)
+
+// remove:
+assert.equal(lru.has('test2'), true)
+lru.remove('test2')
+assert.equal(lru.has('test2'), false)


### PR DESCRIPTION
@clehner this is what I was thinking. don't use `delete` because it's really slow, but set to `undefined`. it's like set but not exactly the same, since a unset key is also undefined, if there isn't already a key there then don't need set it to undefined. this means that remove can't increase the `size` but it can't decrease it either. but that is what we want, since `size` counts the keys. I don't really understand why delete is so slow, but cycling the objects, and letting `_cache` be gc'd is so so much faster than using delete.

This supercedes but includes https://github.com/dominictarr/hashlru/pull/13
and also adds the feature that now defined falsey values (null, false, 0, '') are storeable as keys, which is a non-breaking change with earlier versions.