### PR TITLE
Map is now faster than object (1.5x get, 2.6x set)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Then I realized with this pattern, you _don't actually need_ the linked list any
 This makes a N-2N least recently used cache very very simple. This both has performance benefits,
 and it's also very easy to verify it's correctness.
 
+Over time the `Map` constructor became faster than plain objects, which meant there was no longer a need to work around the delete issue but there are still significant speed benefits to using this approach. 
+
 This algorithm does not give you an ordered list of the N most recently used items,
 but you do not really need that! The property of dropping the least recent items is still preserved.
 

--- a/index.js
+++ b/index.js
@@ -19,9 +19,8 @@ module.exports = function (max) {
       return cache.has(key) || _cache.has(key)
     },
     remove: function (key) {
-      var deleted = cache.delete(key)
-      var _deleted = _cache.delete(key)
-      return deleted || _deleted
+      cache.delete(key)
+      _cache.delete(key)
     },
     get: function (key) {
       if (cache.has(key)) {

--- a/index.js
+++ b/index.js
@@ -2,43 +2,44 @@ module.exports = function (max) {
 
   if (!max) throw Error('hashlru must have a max value, of type number, greater than 0')
 
-  var size = 0, cache = Object.create(null), _cache = Object.create(null)
+  var size = 0, cache = new Map(), _cache = new Map()
 
   function update (key, value) {
-    cache[key] = value
+    cache.set(key, value)
     size ++
     if(size >= max) {
       size = 0
       _cache = cache
-      cache = Object.create(null)
+      cache = new Map()
     }
   }
 
   return {
     has: function (key) {
-      return cache[key] !== undefined || _cache[key] !== undefined
+      return cache.has(key) || _cache.has(key)
     },
     remove: function (key) {
-      if(cache[key] !== undefined)
-        cache[key] = undefined
-      if(_cache[key] !== undefined)
-        _cache[key] = undefined
+      var deleted = cache.delete(key)
+      var _deleted = _cache.delete(key)
+      return deleted || _deleted
     },
     get: function (key) {
-      var v = cache[key]
-      if(v !== undefined) return v
-      if((v = _cache[key]) !== undefined) {
+      if (cache.has(key)) {
+        return cache.get(key)
+      }
+      if (_cache.has(key)) {
+        var v = _cache.get(key)
         update(key, v)
         return v
       }
     },
     set: function (key, value) {
-      if(cache[key] !== undefined) cache[key] = value
+      if (cache.has(key)) cache.set(key, value)
       else update(key, value)
     },
     clear: function () {
-      cache = Object.create(null)
-      _cache = Object.create(null)
+      cache = new Map()
+      _cache = new Map()
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "type": "git",
     "url": "git://github.com/dominictarr/hashlru.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "statistics": "^3.3.0"
+  },
   "devDependencies": {
     "istanbul": "^0.4.5"
   },

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "type": "git",
     "url": "git://github.com/dominictarr/hashlru.git"
   },
-  "dependencies": {
-    "statistics": "^3.3.0"
-  },
   "devDependencies": {
     "istanbul": "^0.4.5"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -44,3 +44,10 @@ assert.equal(lru.has('test2'), false)
 assert.equal(lru.has('test'), true)
 lru.clear()
 assert.equal(lru.has('test'), false)
+
+// object keys
+// set-get:
+var o = {}
+lru.set(o, 'test')
+
+assert.equal(lru.get(o), 'test')


### PR DESCRIPTION
Using `Map` is now significantly faster than using objects, and this has an added advantage of using objects for keys 

bench output for this branch:
```
GET { mean: 54075,
  stdev: 19334.373176059024,
  count: 100,
  sum: 5407500,
  sqsum: 329792361111.1111 }
SET { mean: 14783.333333333345,
  stdev: 1576.1155451425414,
  count: 100,
  sum: 1478333.3333333344,
  sqsum: 22103108465.608475 }
```

bench output for master branch
```
GET { mean: 35880.15873015876,
  stdev: 10512.551706709608,
  count: 100,
  sum: 3588015.873015876,
  sqsum: 139789953388.76306 }
SET { mean: 5580.721850837276,
  stdev: 475.5864362080366,
  count: 100,
  sum: 558072.1850837276,
  sqsum: 3137063883.4717693 }
```