### PR TITLE
fix: type definitions for use with require

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,9 @@
-export default function HLRU(max: number): {
+declare function HLRU(max: number): {
   has: (key: string | number) => boolean;
   remove: (key: string | number) => void;
   get: (key: string | number) => any;
   set: (key: string | number, value: any) => void;
   clear: () => void;
 };
+
+export = HLRU


### PR DESCRIPTION
This pull request fixes typedefs so that module does not pretends to be a ES module, which causes problems like this:

![image](https://user-images.githubusercontent.com/21236/96650938-9d8e6680-12e8-11eb-81a9-651b3a30c70d.png)

And misleads users to do `require('hashlru').default` instead, which than breaks at runtime because there is no `exports.default`.

Suggested syntax is recognized by TS as CommonJS module, which works as expected when importing from commonjs and also works correctly when imported from TS / ESM models if `esModuleInterop: true` is set in `tsconfig.json`